### PR TITLE
docs: migrate all code examples to ReScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ yarn add @urql/rescript
 
 ### Changed
 
-- `reason-urql` is now available as `@urql/rescript`. PR by @parkerziegler [here]().
+- `reason-urql` is now available as `@urql/rescript`. PR by @parkerziegler [here](https://github.com/FormidableLabs/rescript-urql/pull/255).
 - `@urql/rescript` is now compatible with `urql@2.0.0`, `bs-platform@9.0.0`, and `@rescript/react`. You must upgrade to `@rescript/react` from `reason-react` to use v4.0.0. PR by @parkerziegler [here](https://github.com/FormidableLabs/reason-urql/pull/254).
 - The `pollInterval` API was removed from all hooks and Client methods, in accordance with the upstream deprecation of this API in `urql@2.0.0`. PR by @parkerziegler [here](https://github.com/FormidableLabs/reason-urql/pull/254). More information on this deprecation can be found in [the `urql` CHANGELOG](https://github.com/FormidableLabs/urql/releases/tag/urql%402.0.0).
 

--- a/__tests__/Client_test.res
+++ b/__tests__/Client_test.res
@@ -195,19 +195,23 @@ describe("Client", () => {
     })
   })
 
-  describe("with preferGetMethod", () => it("respects the preferGetMethod flag", () => {
+  describe("with preferGetMethod", () =>
+    it("respects the preferGetMethod flag", () => {
       let client = Client.make(~url="https://localhost:3000", ~preferGetMethod=true, ())
 
       open Expect
       expect(client) |> toMatchSnapshot
-    }))
+    })
+  )
 
-  describe("with maskTypename", () => it("respects the maskTypename flag", () => {
+  describe("with maskTypename", () =>
+    it("respects the maskTypename flag", () => {
       let client = Client.make(~url="https://localhost:3000", ~maskTypename=true, ())
 
       open Expect
       expect(client) |> toMatchSnapshot
-    }))
+    })
+  )
 
   describe("Ecosystem exchanges", () => {
     describe("persistedFetchExchange", () => {

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -21,14 +21,13 @@ return <Data data={result.data} />; // Some data UI.
 
 This is fine and works great for JS users, but we have pattern matching in ReScript! Enter `rescript-urql`'s `response` variant. `response` is a single variant with five constructors:
 
-```reason
-type response('response) {
+```rescript
+type response<'data> =
   | Fetching
-  | Data('response)
-  | PartialData('response, GraphQLError.t)
+  | Data('data)
+  | PartialData('data, GraphQLError.t)
   | Error(CombinedError.t)
-  | Empty;
-}
+  | Empty
 ```
 
 This variant is always available on the record returned by `rescript-urql`'s hooks. Let's go over what each constructor (or "tag") means and when you'd want to pattern match on each.

--- a/docs/client-and-provider.md
+++ b/docs/client-and-provider.md
@@ -179,7 +179,7 @@ The same as `Client.executeQuery`, but returns a `Js.Promise.t` rather than a `w
 ```rescript
 open ReScriptUrql
 
-let client = Client.make(~url="https://localhost:3000/graphql", ());
+let client = Client.make(~url="https://localhost:3000/graphql", ())
 
 module GetAllDogs = %graphql(`
   {
@@ -286,7 +286,7 @@ module LikeDog = %graphql(`
       likes
     }
   }
-`);
+`)
 
 Client.mutation(
   ~client,
@@ -302,7 +302,7 @@ Client.mutation(
     } {
     | Data(d) => /* Access data returned from executing the request. */
     | Error(e) => /* Access any errors returned from executing the request. */
-    | _ => /* Fallback if neither Data nor Error return information. */
+    | Empty => /* Fallback if neither Data nor Error return information. */
     }
   });
 ```

--- a/docs/error.md
+++ b/docs/error.md
@@ -2,13 +2,15 @@
 
 Errors in `rescript-urql` are handed to your hooks via a record of type `CombinedError.t`. The record has the following type:
 
-```reason
+```rescript
 type t = {
-  networkError: option(Js.Exn.t),
-  graphQLErrors: option(array(graphQLError)),
-  response: option(Fetch.response),
+  name: string,
   message: string,
-};
+  graphQLErrors: array<GraphQLError.t>,
+  networkError: option<Js.Exn.t>,
+  response: option<Fetch.response>,
+  toString: unit => string,
+}
 ```
 
 In this case, `networkError` returns the original JavaScript error thrown if a network error was encountered. `graphQLErrors` represent an `array` of errors of type `graphQLError`. These represent the errors encountered in the validation or execution stages of interacting with your GraphQL API. `response` is the raw `response` object returned by `fetch`. `message` is a stringified version of either the `networkError` or the `graphQLErrors` – `networkError` will take precedence.
@@ -17,8 +19,8 @@ In this case, `networkError` returns the original JavaScript error thrown if a n
 
 The easiest way to interact with `CombinedError` is through the `message` field on the `CombinedError.t` record. If you just want to display the error message to your user, or operate directly on the error string, simply do the following:
 
-```reason
-switch (response) {
+```rescript
+switch response {
   | Error(e) => <div> e.message->React.string </div>
   | _ => <div />
 }
@@ -26,12 +28,12 @@ switch (response) {
 
 Depending on the types of errors you get from your GraphQL API, you may want to do different things. Here's an example showing how to handle `networkError`s and `graphQLErrors` indepedently.
 
-```reason
-let ({ response }, _) = useQuery(~query=(module MyQuery), ());
+```rescript
+let ({ response }, _) = useQuery(~query=(module MyQuery), ())
 
-switch (response) {
+switch response {
   | Error(e) =>
-    switch (e) {
+    switch e {
     | {networkError: Some(ne)} =>
       <div>
         {ne

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,7 +109,7 @@ let make = (~key: string) => {
   let (_, executeMutation) =
     Hooks.useMutation(~mutation=(module LikeDogMutation))
 
-  <button onClick={_e => executeMutation({key: key}) |> ignore}>
+  <button onClick={_e => executeMutation({key}) |> ignore}>
     "Execute the Mutation (and Reward a Good Dog)"->React.string
   </button>
 }
@@ -129,7 +129,7 @@ let make = (~key: string) => {
     = Hooks.useMutation(~mutation=(module LikeDogMutation))
 
   let button = React.useMemo1(() =>
-    <button onClick={_e => executeMutation({key: key}) |> ignore}>
+    <button onClick={_e => executeMutation({key}) |> ignore}>
       "Execute the Mutation (and Reward a Good Dog)"->React.string
     </button>,
     [executeMutation]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,10 +6,10 @@ This document well help you get started with `rescript-urql`. It picks up right 
 
 To get started with `rescript-urql`, the first thing you'll want to do is create your client. Your client is the core orchestrator of communication with your GraphQL API, handling all outgoing requests and incoming responses. To create a client, call the `make` function from the `Client` module.
 
-```reason
-open ReScriptUrql;
+```rescript
+open ReScriptUrql
 
-let client = Client.make(~url="https://mygraphqlapi.com/graphql", ());
+let client = Client.make(~url="https://mygraphqlapi.com/graphql", ())
 ```
 
 The `client` accepts a few other configuration options, including `fetchOptions` and `exchanges`, but only `url` is required. By default, `rescript-urql` will apply `urql`'s `defaultExchanges` if no exchanges are provided; this will include the `fetchExchange` for executing requests, the `cacheExchange` for caching responses from your API, and the `dedupExchange` for deduplicating in-flight requests. It will also apply standard fetch options if no `fetchOptions` argument is provided, using `POST` as the HTTP method and `application/json` as the `Content-Type` header. We'll see later how to work with these options.
@@ -18,13 +18,13 @@ The `client` accepts a few other configuration options, including `fetchOptions`
 
 Once you have your `Client` setup, you'll need to pass it to your `Provider`, which should wrap the root level of your application. This allows `rescript-urql`'s hooks to access the `Client` in order to execute operations lower down in your React tree.
 
-```reason
-open ReScriptUrql;
+```rescript
+open ReScriptUrql
 
-let client = Client.make(~url="https://mygraphqlapi.com/graphql", ());
+let client = Client.make(~url="https://mygraphqlapi.com/graphql", ())
 
 /* Wrap your application in Provider, passing it the client as a prop. */
-[@react.component]
+@react.component
 let make = () =>
   <Context.Provider value=client><App /></Context.Provider>
 ```
@@ -33,12 +33,11 @@ let make = () =>
 
 Nice, there's only one more step to getting our GraphQL requests executing – using a hook! `rescript-urql` comes with three hooks for getting access to your data – `useQuery`, `useMutation`, and `useSubscription`. Let's check out how we might execute a query with `useQuery`.
 
-```reason
-open ReScriptUrql;
+```rescript
+open ReScriptUrql
 
 /* Create a module with your GraphQL query. */
-module DogsQuery = [%graphql
-  {|
+module DogsQuery = %graphql(`
   query dogs {
     dogs {
       key
@@ -47,31 +46,29 @@ module DogsQuery = [%graphql
       likes
     }
   }
-|}
-];
+`)
 
-[@react.component]
+@react.component
 let make = () => {
   /* Pass the graphql-ppx module as a first-class module to useQuery. */
-  let (Hooks.{response}, executeQuery)
-    = Hooks.useQuery(~query=(module DogsQuery), ());
+  let ({Hooks.response: response}, executeQuery) = Hooks.useQuery(~query=(module DogsQuery), ())
 
   /* Pattern match on the response variant.
   This variant has constructors for Fetching, Data(d), PartialData(d, e) Error(e), and Empty. */
-  switch (response) {
+  switch response {
     | Fetching => <LoadingSpinner />
     | Data(d)
     | PartialData(d, _) => {
       Array.map(dog =>
         <div key=dog.key>
-          <span> {j|$dog.name $dog.likes|j}->React.string </span>
+          <span> dog.name->React.string </span>
           <span> dog.breed->React.string <span>
         </div>,
         d.dogs
       )
     }
     | Error(e) =>
-      switch (e.networkError) {
+      switch e.networkError {
       | Some(_e) => <div> "Network Error"->React.string </div>
       | None => <div> "Other Error"->React.string </div>
       }
@@ -92,30 +89,28 @@ Awesome, so we've written our first query with `rescript-urql`. What about mutat
 
 Fortunately, writing mutations in `rescript-urql` is just as easy as writing queries – just use the `useMutation` hook.
 
-```reason
-open ReScriptUrql;
+```rescript
+open ReScriptUrql
 
-/* Create a module with your GraphQL mutation. */
-module LikeDogMutation = [%graphql
-    {|
-    mutation likeDog($key: ID!) {
-      likeDog(key: $key) {
-        likes
-        name
-        breed
-      }
+// Create a module with your GraphQL mutation.
+module LikeDogMutation = graphql(`
+  mutation likeDog($key: ID!) {
+    likeDog(key: $key) {
+      likes
+      name
+      breed
     }
-  |}
-  ];
+  }
+`)
 
-[@react.component]
+@react.component
 let make = (~key: string) => {
-  /* Pass the request to useMutation. */
+  // Pass the request to useMutation.
   let (_, executeMutation) =
-    Hooks.useMutation(~mutation=(module LikeDogMutation));
+    Hooks.useMutation(~mutation=(module LikeDogMutation))
 
-  <button onClick={_e => executeMutation({key}) |> ignore}>
-      "Execute the Mutation (and Reward a Good Dog)"->React.string
+  <button onClick={_e => executeMutation({key: key}) |> ignore}>
+    "Execute the Mutation (and Reward a Good Dog)"->React.string
   </button>
 }
 ```
@@ -124,30 +119,30 @@ Great – we've successfully executed a mutation to like a dog! Existing queries
 
 `useMutation` returns a two-dimensional tuple, containing `(result, executeMutation)`. `result` contains the `response` variant, which allows you to pattern match on the API response from your mutation. For example, if you wanted to show different UI when your mutation was `Fetching`, or if there was an `Error` you can do something like the following:
 
-```reason
-open ReScriptUrql;
+```rescript
+open ReScriptUrql
 
-[@react.component]
+@react.component
 let make = (~key: string) => {
-  /* Pass the request to useMutation. */
-  let (Hooks.{response}, executeMutation)
-    = Hooks.useMutation(~mutation=(module LikeDogMutation));
+  // Pass the request to useMutation.
+  let ({Hooks.response: response}, executeMutation)
+    = Hooks.useMutation(~mutation=(module LikeDogMutation))
 
   let button = React.useMemo1(() =>
-    <button onClick={_e => executeMutation({key}) |> ignore}>
-        "Execute the Mutation (and Reward a Good Dog)"->React.string
+    <button onClick={_e => executeMutation({key: key}) |> ignore}>
+      "Execute the Mutation (and Reward a Good Dog)"->React.string
     </button>,
-    [|executeMutation|]
+    [executeMutation]
   );
 
-  switch (response) {
+  switch response {
     | Fetching =>
-      /* If the mutation is still executing, display a LoadingSpinner on top of our button. */
+      // If the mutation is still executing, display a LoadingSpinner on top of our button.
       <LoadingSpinner>
         button
       <LoadingSpinner>
     | Data(_d) => button
-    /* If an error is encountered when executing the mutation, show some error UI to the user. */
+    // If an error is encountered when executing the mutation, show some error UI to the user.
     | Error(e) =>
       <MyErrorComponent message=e.message>
         button

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -34,11 +34,10 @@ In this section, we cover the main mechanism for requesting data in `rescript-ur
 
 ### Example
 
-```reason
-open ReScriptUrql;
+```rescript
+open ReScriptUrql
 
-module GetPokémon = [%graphql
-  {|
+module GetPokémon = %graphql(`
   query pokémon($name: String!) {
     pokemon(name: $name) {
       name
@@ -46,15 +45,14 @@ module GetPokémon = [%graphql
       image
     }
   }
-|}
-];
+`)
 
-[@react.component]
+@react.component
 let make = () => {
-  let (Hooks.{response}, reexecuteQuery) =
-    Hooks.useQuery(~query=(module GetPokemon), {name: "Butterfree"});
+  let ({Hooks.response: response}, reexecuteQuery) =
+    Hooks.useQuery(~query=(module GetPokemon), {name: "Butterfree"})
 
-  switch (response) {
+  switch response {
     | Fetching => <div> "Loading"->React.string </div>
     | Data(d)
     | PartialData(d, _e) =>
@@ -65,12 +63,12 @@ let make = () => {
          <button
           onClick={_e =>
             reexecuteQuery(
-              ~requestPolicy=`NetworkOnly,
+              ~requestPolicy=#NetworkOnly,
               ()
             )
           }
          >
-          {j|Refetch data for $d.pokemon.name|j} -> React.string
+          `Refetch data for $d.pokemon.name`->React.string
          </button>
       </div>
     | Error(_e) => <div> "Error"->React.string </div>
@@ -102,22 +100,20 @@ Check out `examples/2-query` to see an example of using the `useQuery` hook.
 
 ### Example
 
-```reason
-open ReScriptUrql;
+```rescript
+open ReScriptUrql
 
-module LikeDog = [%graphql
-    {|
-    mutation likeDog($key: ID!) {
-      likeDog(key: $key) {
-        likes
-      }
+module LikeDog = %graphql(`
+  mutation likeDog($key: ID!) {
+    likeDog(key: $key) {
+      likes
     }
-  |}
-  ];
+  }
+`)
 
-[@react.component]
+@react.component
 let make = (~id) => {
-  let (_, executeMutation) = Hooks.useMutation(~mutation=(module LikeDog));
+  let (_, executeMutation) = Hooks.useMutation(~mutation=(module LikeDog))
 
   <button onClick={_e => executeMutation({key: id}) |> ignore}>
     "Like This Dog!"->React.string
@@ -160,35 +156,33 @@ If using the `useSubscription` hook, be sure your client is configured with the 
 
 ### Example
 
-```reason
-open ReScriptUrql;
+```rescript
+open ReScriptUrql
 
-module SubscribeRandomInt = [%graphql
-  {|
+module SubscribeRandomInt = %graphql(`
   subscription subscribeNumbers {
     newNumber
   }
-|}
-];
+`)
 
 /* Accumulate subscriptions as new values arrive from your GraphQL endpoint. */
 let handler = (prevSubscriptions, subscription) => {
-  switch (prevSubscriptions) {
-  | Some(subs) => Array.append(subs, [|subscription|])
-  | None => [|subscription|]
-  };
-};
+  switch prevSubscriptions {
+  | Some(subs) => Array.append(subs, [subscription])
+  | None => [subscription]
+  }
+}
 
-[@react.component]
+@react.component
 let make = () => {
-  let (Hooks.{response}) =
+  let ({Hooks.response: response}) =
     Hooks.useSubscription(
       ~request=(module SubscribeRandomInt),
       ~handler=Handler(handler),
       ()
-    );
+    )
 
-  switch (response) {
+  switch response {
     | Fetching => <text> "Loading"->React.string </text>
     | Data(d)
     | PartialData(d, _e) =>
@@ -224,10 +218,10 @@ Check out `examples/5-subscription` to see an example of using the `useSubscript
 
 ### Example
 
-```reason
-open ReScriptUrql;
+```rescript
+open ReScriptUrql
 
-module GetAllDogs = [%graphql {|
+module GetAllDogs = %graphql(`
   query dogs {
     dogs {
       name
@@ -235,18 +229,18 @@ module GetAllDogs = [%graphql {|
       likes
     }
   }
-|}];
+`)
 
-[@react.component]
+@react.component
 let make = () => {
-  let client = Hooks.useClient();
+  let client = Hooks.useClient()
 
   React.useEffect1(() => {
     let subscription = Client.executeQuery(~client, ~query=(module GetDogs), ())
-      |> Wonka.subscribe((. result) => Js.log(result));
+      |> Wonka.subscribe((. result) => Js.log(result))
 
     Some(subscription.unsubscribe);
-  }, [|client|]);
+  }, [client]);
 
   <div> "You can now use your client!"->React.string </div>
 }


### PR DESCRIPTION
Fix #246 

This PR migrates all of our examples in documentation to ReScript! We had several Reason code samples lying around for a long time, but with the recent rename and republish, it's best to have all of our examples in our target source language.